### PR TITLE
README: added 'uid' to example of message iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ messages_folder = imbox.messages(folder='Social')
 
 
 
-for message in all_messages:
+for uid, message in all_messages:
 	........
 # Every message is an object with the following keys
 	


### PR DESCRIPTION
I just came across 'imbox' and was using the README to get started when I discovered this discrepancy.
