### PR TITLE
Fix: imbox crashes when inbox is empty.

### DIFF
--- a/imbox/__init__.py
+++ b/imbox/__init__.py
@@ -20,6 +20,8 @@ class Imbox(object):
         query = build_search_query(**kwargs)
 
         message, data = self.connection.uid('search', None, query)
+        if data[0] is None:
+            return []
         return data[0].split()
 
     def fetch_by_uid(self, uid):


### PR DESCRIPTION
If mailbox is empty `SEARCH` command returns `[None]`, so `split()` on `None` fails.