### PR TITLE
Fix unicode support

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -115,9 +115,10 @@ def parse_attachment(message_part):
 def decode_content(message):
     content = message.get_payload(decode=True)
     charset = message.get_content_charset('utf-8')
-    if charset != 'utf-8':
+    try:
         return content.decode(charset)
-    return content
+    except AttributeError:
+        return content
 
 
 def parse_email(raw_email):


### PR DESCRIPTION
I had an issue when parsing a mail containing the following string:

Testing «ταБЬℓσ»: 1<2 & 4+1>3, now 20% off!

This returned an object of type string with unicode literals in there. When later joining it with a unicode object this failed. The proposed changes correctly return a unicode object in all circumstances.