### PR TITLE
Attachments cannot be multipart messages, so check this.

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -83,7 +83,7 @@ def decode_param(param):
 def parse_attachment(message_part):
     # Check again if this is a valid attachment
     content_disposition = message_part.get("Content-Disposition", None)
-    if content_disposition is not None:
+    if content_disposition is not None and not message_part.is_multipart():
         dispositions = content_disposition.strip().split(";")
 
         if dispositions[0].lower() in ["attachment", "inline"]:


### PR DESCRIPTION
Sometimes when trying to read emails, a traceback like this is produced:

    Traceback (most recent call last):
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/cherrypy/_cprequest.py", line 670, in respond
        response.body = self.handler()
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/cherrypy/lib/encoding.py", line 217, in __call__
        self.body = self.oldhandler(*args, **kwargs)
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/cherrypy/_cpdispatch.py", line 61, in __call__
        return self.callable(*self.args, **self.kwargs)
      File "/shared/opt/ParrotCage/parrotcage/web/quotes.py", line 155, in POST
        quotes.process_emails(session)
      File "/shared/opt/ParrotCage/parrotcage/quotes.py", line 99, in process_emails
        for uid, email in reversed(list(new_emails)):
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/imbox/__init__.py", line 39, in fetch_list
        yield (uid, self.fetch_by_uid(uid))
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/imbox/__init__.py", line 31, in fetch_by_uid
        email_object = parse_email(raw_email)
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/imbox/parser.py", line 144, in parse_email
        attachment = parse_attachment(part)
      File "/shared/opt/pcvenv/local/lib/python2.7/site-packages/imbox/parser.py", line 89, in parse_attachment
        'size': len(file_data),
    TypeError: object of type 'NoneType' has no len()

The cause of this appears to be that imbox is trying to consume multipart message parts as attachments. I didn't get to the root cause of this, but I added a check. Please reject this pull request if there is a more elegant way of doing this. Unfortunately, I cannot share the emails that cause this due to their proprietary content, I wonder whether they might be malformed, but this makes imbox handle them as I'd expect it to.