### PR TITLE
fix bug in the logger of decode_mail_header

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -35,7 +35,7 @@ def decode_mail_header(value, default_charset='us-ascii'):
         return str_decode(str_encode(value, default_charset, 'replace'), default_charset)
     else:
         for index, (text, charset) in enumerate(headers):
-            logger.debug("Mail header no. {}: {} encoding {}".format(index, str_decode(text, 'utf-8'), charset))
+            logger.debug("Mail header no. {}: {} encoding {}".format(index, str_decode(text, charset or 'utf-8'), charset))
             try:
                 headers[index] = str_decode(text, charset or default_charset,
                                             'replace')


### PR DESCRIPTION
When the mail header has Chinese words and encoded in GBK, the logger.debug will throw exceptions as follows:
`UnicodeDecodeError: 'utf8' codec can't decode byte 0xd4 in position 0: invalid continuation byte` in `str_decode(text, 'utf-8')`