### PR TITLE
Make sure that a part is actually text before we try to decode it.

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -143,8 +143,9 @@ def parse_email(raw_email):
         logger.debug("Multipart message. Will process parts.")
         for part in email_message.walk():
             content_type = part.get_content_type()
+            part_maintype = part.get_content_maintype()
             content_disposition = part.get('Content-Disposition', None)
-            if content_disposition:
+            if content_disposition or not part_maintype == "text":
                 content = part.get_payload(decode=True)
             else:
                 content = decode_content(part)


### PR DESCRIPTION
I'm seeing a regular issue with imbox where it fails with a UnicodeDecodeError. This seems to be because it is trying to decode non-text fragments of the e-mail. This pull request checks the content type rather than just looking at the content disposition. I'm not sure whether the e-mails are malformed or not, but either way I think the exception should be avoided.