### PR TITLE
Fix UnicodeDecodeError when parsing headers with python 3

### DIFF
--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -13,7 +13,7 @@ if PY3:
         if isinstance(value, str):
             return bytes(value, encoding, errors).decode('utf-8')
         elif isinstance(value, bytes):
-            return value.decode('utf-8', errors=errors)
+            return value.decode(encoding or 'utf-8', errors=errors)
         else:
             raise TypeError( "Cannot decode '{}' object".format(value.__class__) )
 else:

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -1,3 +1,4 @@
+# Encoding: utf-8
 from __future__ import unicode_literals
 import unittest
 from imbox.parser import *
@@ -35,6 +36,25 @@ Hi, this is a test email with no <span style="font-weight: bold;">attachments</s
 --------------080505090108000500080106--
 """
 
+raw_email_encoded = b"""Delivered-To: receiver@example.com
+Return-Path: <sender@example.com>
+Date: Sat, 26 Mar 2016 13:55:30 +0300 (FET)
+From: sender@example.com
+To: receiver@example.com
+Message-ID: <811170233.1296.1345983710614.JavaMail.bris@BRIS-AS-NEW.site>
+Subject: =?ISO-8859-5?B?suvf2OHa0CDf3iDa0ODi1Q==?=
+MIME-Version: 1.0
+Content-Type: multipart/mixed; 
+	boundary="----=_Part_1295_1644105626.1458989730614"
+
+------=_Part_1295_1644105626.1458989730614
+Content-Type: text/html; charset=ISO-8859-5
+Content-Transfer-Encoding: quoted-printable
+
+=B2=EB=DF=D8=E1=DA=D0 =DF=DE =DA=D0=E0=E2=D5 1234
+------=_Part_1295_1644105626.1458989730614--
+"""
+
 
 class TestParser(unittest.TestCase):
 
@@ -45,6 +65,12 @@ class TestParser(unittest.TestCase):
         self.assertEqual('Test email - no attachment', parsed_email.subject)
         self.assertEqual('Tue, 30 Jul 2013 15:56:29 +0300', parsed_email.date)
         self.assertEqual('<test0@example.com>', parsed_email.message_id)
+
+    def test_parse_email_encoded(self):
+        parsed_email = parse_email(raw_email_encoded)
+
+        self.assertEqual('Выписка по карте', parsed_email.subject)
+        self.assertEqual('Выписка по карте 1234', parsed_email.body['html'][0])
 
     def test_parse_email_ignores_header_casing(self):
         self.assertEqual('one', parse_email('Message-ID: one').message_id)


### PR DESCRIPTION
I got an error when parsing encoded subject. This patch fixes it