### PR TITLE
Check SSL-Context for IMAP4_SSL connections

### DIFF
--- a/imbox/__init__.py
+++ b/imbox/__init__.py
@@ -8,9 +8,11 @@ logger = logging.getLogger(__name__)
 
 class Imbox(object):
 
-    def __init__(self, hostname, username=None, password=None, ssl=True, port=None):
+    def __init__(self, hostname, username=None, password=None, ssl=True,
+                 port=None, ssl_context=None):
 
-        self.server = ImapTransport(hostname, ssl=ssl, port=port)
+        self.server = ImapTransport(hostname, ssl=ssl, port=port,
+                                    ssl_context=None)
         self.hostname = hostname
         self.username = username
         self.password = password

--- a/imbox/imap.py
+++ b/imbox/imap.py
@@ -11,22 +11,19 @@ class ImapTransport(object):
     def __init__(self, hostname, port=None, ssl=True, usesslcontext=True):
         self.hostname = hostname
         self.port = port
+        kwargs = {}
 
         if ssl:
-            if usesslcontext is True:
-                context = pythonssllib.create_default_context()
-            else:
-                context = None
-
+            self.transport = IMAP4_SSL
             if not self.port:
                 self.port = 993
-            self.server = self.IMAP4_SSL(self.hostname, self.port,
-                                         ssl_context=context)
+            kwargs["ssl_context"] = pythonssllib.create_default_context()
         else:
+            self.transport = IMAP4
             if not self.port:
                 self.port = 143
 
-        self.server = self.IMAP4(self.hostname, self.port)
+        self.server = self.transport(self.hostname, self.port, **kwargs)
         logger.debug("Created IMAP4 transport for {host}:{port}"
                      .format(host=self.hostname, port=self.port))
 

--- a/imbox/imap.py
+++ b/imbox/imap.py
@@ -13,7 +13,7 @@ class ImapTransport(object):
         self.port = port
 
         if ssl:
-            if usesslcontext = True:
+            if usesslcontext is True:
                 context = pythonssllib.create_default_context()
             else:
                 context = None

--- a/imbox/imap.py
+++ b/imbox/imap.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class ImapTransport(object):
 
-    def __init__(self, hostname, port=None, ssl=True, usesslcontext=True):
+    def __init__(self, hostname, port=None, ssl=True, ssl_context=None):
         self.hostname = hostname
         self.port = port
         kwargs = {}
@@ -17,7 +17,9 @@ class ImapTransport(object):
             self.transport = IMAP4_SSL
             if not self.port:
                 self.port = 993
-            kwargs["ssl_context"] = pythonssllib.create_default_context()
+            if ssl_context is None:
+                ssl_context = pythonssllib.create_default_context()
+            kwargs["ssl_context"] = ssl_context
         else:
             self.transport = IMAP4
             if not self.port:

--- a/imbox/imap.py
+++ b/imbox/imap.py
@@ -1,25 +1,34 @@
 from imaplib import IMAP4, IMAP4_SSL
 
 import logging
+import ssl as pythonssllib
+
 logger = logging.getLogger(__name__)
+
 
 class ImapTransport(object):
 
-    def __init__(self, hostname, port=None, ssl=False):
+    def __init__(self, hostname, port=None, ssl=True, usesslcontext=True):
         self.hostname = hostname
         self.port = port
 
         if ssl:
-            self.transport = IMAP4_SSL
+            if usesslcontext = True:
+                context = pythonssllib.create_default_context()
+            else:
+                context = None
+
             if not self.port:
                 self.port = 993
+            self.server = self.IMAP4_SSL(self.hostname, self.port,
+                                         ssl_context=context)
         else:
-            self.transport = IMAP4
             if not self.port:
                 self.port = 143
 
-        self.server = self.transport(self.hostname, self.port)
-        logger.debug("Created IMAP4 transport for {host}:{port}".format(host=self.hostname, port=self.port))
+        self.server = self.IMAP4(self.hostname, self.port)
+        logger.debug("Created IMAP4 transport for {host}:{port}"
+                     .format(host=self.hostname, port=self.port))
 
     def list_folders(self):
         logger.debug("List all folders in mailbox")
@@ -28,5 +37,6 @@ class ImapTransport(object):
     def connect(self, username, password):
         self.server.login(username, password)
         self.server.select()
-        logger.debug("Logged into server {} and selected mailbox 'INBOX'".format(self.hostname))
+        logger.debug("Logged into server {} and selected mailbox 'INBOX'"
+                     .format(self.hostname))
         return self.server


### PR DESCRIPTION
As described in https://github.com/martinrusev/imbox/issues/68 imbox does currently not validate ssl certificates.

This PR introduces this validation.

Please note, that this fix might be incompatible with existing programs which rely on these missing checks.