### PR TITLE
Permissively Decode Emails

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -116,7 +116,7 @@ def decode_content(message):
     content = message.get_payload(decode=True)
     charset = message.get_content_charset('utf-8')
     try:
-        return content.decode(charset)
+        return content.decode(charset, 'ignore')
     except AttributeError:
         return content
 


### PR DESCRIPTION
Email providers throw all kinds of garbage in their emails - even Gmail and Thunderbird send invalid UTF-8 in certain cases. Not throwing UnicodeErrors every time an email provider screws up their UTF-8 would really help QOL when using this library.