### PR TITLE
Update link to python3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Usage
 ```python
 from imbox import Imbox
 
-# SSL Context docs https://docs.python.org/2/library/ssl.html#ssl.create_default_context
+# SSL Context docs https://docs.python.org/3/library/ssl.html#ssl.create_default_context
 
 imbox = Imbox('imap.gmail.com',
 		username='username', 


### PR DESCRIPTION
According to setup.py, the library is compatible only with python3 so the link to python documentation should go to python3 too. The content does not change between the 2 versions, except the 'Changed in version' which fits correct python versions.