### PR TITLE
Print in python 3 needs parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ for uid, message in all_messages:
 	message.attachments
 
 # To check all available keys
-	print message.keys()
+	print(message.keys())
 
 
 # To check the whole object, just write
 
-	print message
+	print(message)
 
 	{
 	'headers': 


### PR DESCRIPTION
Fix the examples by using print() instead of print statement because the library is python 3  only