### PR TITLE
Remove instructions needed for python2 compatibility

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -1,6 +1,4 @@
-from __future__ import unicode_literals
-from six import BytesIO, binary_type
-
+import io
 import re
 import email
 import base64
@@ -92,7 +90,7 @@ def parse_attachment(message_part):
             attachment = {
                 'content-type': message_part.get_content_type(),
                 'size': len(file_data),
-                'content': BytesIO(file_data)
+                'content': io.BytesIO(file_data)
             }
             filename = message_part.get_param('name')
             if filename:
@@ -122,7 +120,7 @@ def decode_content(message):
 
 
 def parse_email(raw_email, policy=None):
-    if isinstance(raw_email, binary_type):
+    if isinstance(raw_email, bytes):
         raw_email = str_encode(raw_email, 'utf-8')
     if policy is not None:
         email_parse_kwargs = dict(policy=policy)

--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -1,24 +1,16 @@
 from __future__ import unicode_literals
-from six import PY3
 
 import logging
 logger = logging.getLogger(__name__)
 
-if PY3:
-    def str_encode(value='', encoding=None, errors='strict'):
-        logger.debug("Encode str {} with and errors {}".format(value, encoding, errors))
-        return str(value, encoding, errors)
+def str_encode(value='', encoding=None, errors='strict'):
+    logger.debug("Encode str {} with and errors {}".format(value, encoding, errors))
+    return str(value, encoding, errors)
 
-    def str_decode(value='', encoding=None, errors='strict'):
-        if isinstance(value, str):
-            return bytes(value, encoding, errors).decode('utf-8')
-        elif isinstance(value, bytes):
-            return value.decode(encoding or 'utf-8', errors=errors)
-        else:
-            raise TypeError( "Cannot decode '{}' object".format(value.__class__) )
-else:
-    def str_encode(string='', encoding=None, errors='strict'):
-        return unicode(string, encoding, errors)
-
-    def str_decode(value='', encoding=None, errors='strict'):
-        return value.decode(encoding, errors)
+def str_decode(value='', encoding=None, errors='strict'):
+    if isinstance(value, str):
+        return bytes(value, encoding, errors).decode('utf-8')
+    elif isinstance(value, bytes):
+        return value.decode(encoding or 'utf-8', errors=errors)
+    else:
+        raise TypeError( "Cannot decode '{}' object".format(value.__class__) )

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     packages=['imbox'],
     package_dir={'imbox': 'imbox'},
     zip_safe=False,
-    install_requires=['six'],
     classifiers=(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.2',

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -1,10 +1,8 @@
-# Encoding: utf-8
-from __future__ import unicode_literals
 import unittest
 from imbox.parser import *
 
 import sys
-if sys.version_info.major < 3 or sys.version_info.minor < 3:
+if sys.version_info.minor < 3:
     SMTP = False
 else:
     from email.policy import SMTP


### PR DESCRIPTION
These instructions are needed only for python2 compatibility. imbox is python3 only so they can be removed.