### PR TITLE
Explicit object inheritance in not necessary in python3

### DIFF
--- a/imbox/__init__.py
+++ b/imbox/__init__.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Imbox(object):
+class Imbox:
 
     def __init__(self, hostname, username=None, password=None, ssl=True,
                  port=None, ssl_context=None, policy=None):

--- a/imbox/imap.py
+++ b/imbox/imap.py
@@ -6,7 +6,7 @@ import ssl as pythonssllib
 logger = logging.getLogger(__name__)
 
 
-class ImapTransport(object):
+class ImapTransport:
 
     def __init__(self, hostname, port=None, ssl=True, ssl_context=None):
         self.hostname = hostname

--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class Struct(object):
+class Struct:
     def __init__(self, **entries):
         self.__dict__.update(entries)
 


### PR DESCRIPTION
so ```class X(object):``` is writable ```class X:```