### PR TITLE
Add info about how to run tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Python library for reading IMAP mailboxes and converting email content to machin
 Requirements
 ------------
 
-Python (3.2, 3.3, 3.4, 3.5, 3.6)
+Python (3.3, 3.4, 3.5, 3.6)
 
 
 Installation
@@ -114,4 +114,25 @@ Usage
             }
 
 
+Changelog
+---------
+
 `Changelog <https://github.com/martinrusev/imbox/blob/master/CHANGELOG.md>`_
+
+
+Running the tests
+-----------------
+
+You can run the imbox tests with ``tox``.
+
+Requirements:
+ * the supported python versions
+ * ``tox``. Tox is packaged in Debian and derivatives distributions.
+
+On Ubuntu, you can install several python versions with:
+
+.. code:: sh
+
+    sudo add-apt-repository ppa:deadsnakes/ppa
+    sudo apt update
+    sudo apt install python3.X

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     zip_safe=False,
     classifiers=(
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py33,py34,py35,py36
+
+[testenv]
+deps=nose
+commands=nosetests -v


### PR DESCRIPTION
This pull-request inserts the data provided in issue #101 into README.rst file. 

The patch removes python 3.2 from supported versions.

I checked that html is correctly generated from README.rst file by rst2html.