### PR TITLE
Remove double-quotes around attachment filename

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -105,7 +105,7 @@ def parse_attachment(message_part):
                     name, value = decode_param(param)
 
                     if 'file' in name:
-                        attachment['filename'] = value
+                        attachment['filename'] = value[1:-1] if value.startswith('"') else value
 
                     if 'create-date' in name:
                         attachment['create-date'] = value

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -321,7 +321,7 @@ class TestParser(unittest.TestCase):
         attachment = parsed_email.attachments[0]
         self.assertEqual('application/octet-stream', attachment['content-type'])
         self.assertEqual(71, attachment['size'])
-        self.assertEqual('"abc.xyz"', attachment['filename'])
+        self.assertEqual('abc.xyz', attachment['filename'])
         self.assertTrue(attachment['content'])
 
     # TODO - Complete the test suite


### PR DESCRIPTION
The patch fixes the doubles-quotes in the attachement filename. The patch takes care if there is no double-quotes. I have no idea is this case could happen so I wxanted to be protective.

I discovered this case with pull-request #100 