### PR TITLE
Query and mark emails as flagged/starred.

### DIFF
--- a/imbox/__init__.py
+++ b/imbox/__init__.py
@@ -60,6 +60,10 @@ class Imbox:
         logger.info("Mark UID {} with \\Seen FLAG".format(int(uid)))
         self.connection.uid('STORE', uid, '+FLAGS', '(\\Seen)')
 
+    def mark_flag(self, uid):
+        logger.info("Mark UID {} with \\Flagged FLAG".format(int(uid)))
+        self.connection.uid('STORE', uid, '+FLAGS', '(\\Flagged)')
+
     def delete(self, uid):
         logger.info("Mark UID {} with \\Deleted FLAG and expunge.".format(int(uid)))
         mov, data = self.connection.uid('STORE', uid, '+FLAGS', '(\\Deleted)')

--- a/imbox/query.py
+++ b/imbox/query.py
@@ -17,6 +17,8 @@ def build_search_query(**kwargs):
 
     # Parse keyword arguments
     unread = kwargs.get('unread', False)
+    unflagged = kwargs.get('unflagged', False)
+    flagged = kwargs.get('flagged', False)
     sent_from = kwargs.get('sent_from', False)
     sent_to = kwargs.get('sent_to', False)
     date__gt = kwargs.get('date__gt', False)
@@ -31,6 +33,12 @@ def build_search_query(**kwargs):
 
     if unread:
         query.append("(UNSEEN)")
+
+    if unflagged:
+        query.append("(UNFLAGGED)")
+
+    if flagged:
+        query.append("(FLAGGED)")
 
     if sent_from:
         query.append('(FROM "%s")' % sent_from)

--- a/tests/query_tests.py
+++ b/tests/query_tests.py
@@ -15,6 +15,16 @@ class TestQuery(unittest.TestCase):
         res = build_search_query(unread=True)
         self.assertEqual(res, "(UNSEEN)")
 
+    def test_unflagged(self):
+
+        res = build_search_query(unflagged=True)
+        self.assertEqual(res, "(UNFFLAGGED)")
+
+    def test_flagged(self):
+
+        res = build_search_query(flagged=True)
+        self.assertEqual(res, "(FLAGGED)")
+
     def test_sent_from(self):
 
         res = build_search_query(sent_from='test@example.com')

--- a/tests/query_tests.py
+++ b/tests/query_tests.py
@@ -18,7 +18,7 @@ class TestQuery(unittest.TestCase):
     def test_unflagged(self):
 
         res = build_search_query(unflagged=True)
-        self.assertEqual(res, "(UNFFLAGGED)")
+        self.assertEqual(res, "(UNFLAGGED)")
 
     def test_flagged(self):
 


### PR DESCRIPTION
1. imbox provides option to mark emails to seen using `message.mark_seen(uid)`  option. Like that its good have `message.mark_seen(uid)`. This will stars or flags an email.

2. imbox provides option to  filter emails using `imbox.messages(unread=True)` option. Like that its good have `imbox.messages(unflagged=True)` or `imbox.messages(flagged=True)`. This will filter emails using stars or flags state.

