### PR TITLE
Fix spelling error in log

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -54,7 +54,7 @@ def get_mail_addresses(message, header_name):
     for index, (address_name, address_email) in enumerate(addresses):
         addresses[index] = {'name': decode_mail_header(address_name),
                             'email': address_email}
-        logger.debug("{} Mail addressees in message: <{}> {}".format(header_name.upper(), address_name, address_email))
+        logger.debug("{} Mail address in message: <{}> {}".format(header_name.upper(), address_name, address_email))
     return addresses
 
 


### PR DESCRIPTION
I wonder if you wanted to write 'address' in plural or not. I modified to singular because there is only one address for each log line. 