### PR TITLE
Reuse __version__ for the library version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 from setuptools import setup
 import os
 
-version = '0.9.5'
+import imbox
+
+version = imbox.__version__
 
 
 def read(filename):


### PR DESCRIPTION
The version  (currently 0.9.5) is set in two files. This PR reuses one constant to set the other one. So it respects DRY.

I wonder if the temporary ```version``` variable should be removed so the parameter of ```setup()``` would use ```imbox.__version__``` directly.

What do you think about it?