### PR TITLE
Add a forgotten parameter in a log line

### DIFF
--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -3,7 +3,10 @@ logger = logging.getLogger(__name__)
 
 
 def str_encode(value='', encoding=None, errors='strict'):
-    logger.debug("Encode str {} with and errors {}".format(value, encoding, errors))
+    logger.debug("Encode str {value} with encoding {encoding} and errors {errors}".format(
+        value=value,
+        encoding=encoding,
+        errors=errors))
     return str(value, encoding, errors)
 
 


### PR DESCRIPTION
So the `encoding` parameter will be logged.

I changed the formatted string to not raise an error if the `encoding` parameter equals `None`. However, it should never occur and type hint enforces to string type.

Tested with python 3.6