### PR TITLE
Add vendors directory to package

### DIFF
--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -3,10 +3,7 @@ logger = logging.getLogger(__name__)
 
 
 def str_encode(value='', encoding=None, errors='strict'):
-    logger.debug("Encode str {value} with encoding {encoding} and errors {errors}".format(
-        value=value,
-        encoding=encoding,
-        errors=errors))
+    logger.debug("Encode str {} with and errors {}".format(value, encoding, errors))
     return str(value, encoding, errors)
 
 

--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -3,7 +3,10 @@ logger = logging.getLogger(__name__)
 
 
 def str_encode(value='', encoding=None, errors='strict'):
-    logger.debug("Encode str {} with and errors {}".format(value, encoding, errors))
+    logger.debug("Encode str {value} with encoding {encoding} and errors {errors}".format(
+        value=value,
+        encoding=encoding,
+        errors=errors))
     return str(value, encoding, errors)
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author_email='martin@amon.cx',
     url='https://github.com/martinrusev/imbox',
     license='MIT',
-    packages=['imbox'],
+    packages=['imbox', 'imbox.vendors'],
     package_dir={'imbox': 'imbox'},
     zip_safe=False,
     classifiers=(


### PR DESCRIPTION
Currently, `vendors/` directory is not added, so `imbox` is not usable because there is an `ImportError`.

Currently, it occurs only if the git repository is used directly but the issue will appear in pypi.org when you will upload a new release.