### PR TITLE
fix: readd the flag Deleted to delete a message

### DIFF
--- a/imbox/imbox.py
+++ b/imbox/imbox.py
@@ -62,6 +62,7 @@ class Imbox:
 
     def delete(self, uid):
         logger.info("Mark UID {} with \\Deleted FLAG and expunge.".format(int(uid)))
+        self.connection.uid('STORE', uid, '+FLAGS', '(\\Deleted)')
         self.connection.expunge()
 
     def copy(self, uid, destination_folder):


### PR DESCRIPTION
The messages are not deleted currently because an accidental removal of this line (see #138). It's readded, without the variables `mov` and `data` because they are not used.