### PR TITLE
Add query uid__range

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,9 @@ Usage
         # Messages whose subjects contain a string
         inbox_messages_subject_christmas = imbox.messages(subject='Christmas')
 
+        # Messages whose UID is greater than 1050
+        inbox_messages_subject_christmas = imbox.messages(uid__range='1050:*')
+
         # Messages from a specific folder
         messages_in_folder_social = imbox.messages(folder='Social')
 

--- a/imbox/query.py
+++ b/imbox/query.py
@@ -23,6 +23,7 @@ def build_search_query(**kwargs):
     date__lt = kwargs.get('date__lt', False)
     date__on = kwargs.get('date__on', False)
     subject = kwargs.get('subject')
+    uid__range = kwargs.get('uid__range')
 
     query = []
 
@@ -52,6 +53,9 @@ def build_search_query(**kwargs):
 
     if subject is not None:
         query.append('(SUBJECT "%s")' % subject)
+
+    if uid__range:
+        query.append('(UID %s)' % uid__range)
 
     if query:
         logger.debug("IMAP query: {}".format(" ".join(query)))

--- a/tests/query_tests.py
+++ b/tests/query_tests.py
@@ -48,3 +48,7 @@ class TestQuery(unittest.TestCase):
     def test_date__on(self):
         res = build_search_query(date__on=date(2014, 1, 1))
         self.assertEqual(res, '(ON "01-Jan-2014")')
+
+    def test_uid__range(self):
+        res = build_search_query(uid__range='1000:*')
+        self.assertEqual(res, '(UID 1000:*)')


### PR DESCRIPTION
Adds support for queries supporting UID range search, such as:

```python
messages = imbox.messages(uid__range='1000:2000')
messages = imbox.messages(uid__range='1000:*')  # Messages having UID greater than 1000
```

Related to issue #152.