### PR TITLE
fix multipart filename disposition

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -101,7 +101,8 @@ def parse_attachment(message_part):
             attachment = {
                 'content-type': message_part.get_content_type(),
                 'size': len(file_data),
-                'content': io.BytesIO(file_data)
+                'content': io.BytesIO(file_data),
+                'filename': "",
             }
             filename = message_part.get_param('name')
             if filename:
@@ -112,7 +113,7 @@ def parse_attachment(message_part):
                     name, value = decode_param(param)
 
                     if 'file' in name:
-                        attachment['filename'] = value[1:-
+                        attachment['filename'] += value[1:-
                                                        1] if value.startswith('"') else value
 
                     if 'create-date' in name:


### PR DESCRIPTION
When attach filename is too long the function parse_attachment returns only last part name of the file.

As example:

> Content-Disposition: attachment; 
>  filename*0="2019-09-22-is_a_vee-.ryyyyyyyyyyy_looooong_name_______file.cs";
>  filename*1="v.zip"

so function parse_attachment returns as filename "v.zip".
