### PR TITLE
Attachments now getting Content-ID

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -101,7 +101,8 @@ def parse_attachment(message_part):
             attachment = {
                 'content-type': message_part.get_content_type(),
                 'size': len(file_data),
-                'content': io.BytesIO(file_data)
+                'content': io.BytesIO(file_data),
+                'content-id': message_part.get("Content-ID", None)
             }
             filename = message_part.get_param('name')
             if filename:


### PR DESCRIPTION
Fetching the content-id of attachments in case they exist.
This is needed in case there are attached images placed inside the html