### PR TITLE
Fix for attachments with long file names

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -113,8 +113,12 @@ def parse_attachment(message_part):
                     name, value = decode_param(param)
 
                     if 'file' in name:
-                        attachment['filename'] = value[1:-
-                                                       1] if value.startswith('"') else value
+                        if str(name).endswith("*0"):
+                            attachment['filename'] = value[1:-
+                                                           1] if value.startswith('"') else value
+                        else:
+                            attachment['filename'] += value[1:-
+                                                            1] if value.startswith('"') else value
 
                     if 'create-date' in name:
                         attachment['create-date'] = value


### PR DESCRIPTION
When an attachment has a long file name, there will be multiple dispositions with parameters named file name (for example: filename*0, filename*1 etc). The current code, first saves the filename correctly but then overwrites it with every filename* property. I propose concatenating instead of overwriting.