### PR TITLE
Fix handling for attachments with file names longer than 76 characters 

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -108,21 +108,24 @@ def parse_attachment(message_part):
             if filename:
                 attachment['filename'] = filename
 
+            filename_parts = []
             for param in dispositions[1:]:
                 if param:
                     name, value = decode_param(param)
 
-                    if 'file' in name:
-                        if str(name).endswith("*0"):
-                            attachment['filename'] = value[1:-
-                                                           1] if value.startswith('"') else value
+                    # Check for split filename
+                    s_name = name.split("*")
+                    if s_name[0] == 'filename':
+                        # If this is a split file name - use the number after the * as an index to insert this part
+                        if len(s_name) > 1:
+                            filename_parts.insert(int(s_name[1]),value[1:-1] if value.startswith('"') else value)
                         else:
-                            attachment['filename'] += value[1:-
-                                                            1] if value.startswith('"') else value
+                            filename_parts.insert(0,value[1:-1] if value.startswith('"') else value)
 
                     if 'create-date' in name:
                         attachment['create-date'] = value
 
+            attachment['filename'] = "".join(filename_parts)
             return attachment
 
     return None

--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -113,8 +113,12 @@ def parse_attachment(message_part):
                     name, value = decode_param(param)
 
                     if 'file' in name:
-                        attachment['filename'] = value[1:-
-                                                       1] if value.startswith('"') else value
+                        if str(name).endswith("*0"):
+                            attachment['filename'] = value[1:-
+                                                           1] if value.startswith('"') else value
+                        else:
+                            attachment['filename'] += value[1:-
+                                                            1] if value.startswith('"') else value
 
                     if 'create-date' in name:
                         attachment['create-date'] = value

--- a/tests/parser_tests.py
+++ b/tests/parser_tests.py
@@ -274,6 +274,59 @@ R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==
 --____NOIBTUQXSYRVOOAFLCHY____--
 """
 
+raw_email_with_long_filename_attachment = b"""Delivered-To: receiver@example.com
+Return-Path: <sender@example.com>
+Mime-Version: 1.0
+Date: Wed, 22 Mar 2017 15:21:55 -0500
+Message-ID: <58D29693.192A.0075.1@wimort.com>
+Subject: Re: Reaching Out About Peoples Home Equity
+From: sender@example.com
+To: receiver@example.com
+Content-Type: multipart/alternative; boundary="____NOIBTUQXSYRVOOAFLCHY____"
+
+
+--____NOIBTUQXSYRVOOAFLCHY____
+Content-Type: text/plain; charset=iso-8859-15
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline;
+	modification-date="Wed, 22 Mar 2017 15:21:55 -0500"
+
+Hello Chloe
+
+--____NOIBTUQXSYRVOOAFLCHY____
+Content-Type: multipart/related; boundary="____XTSWHCFJMONXSVGPVDLY____"
+
+
+--____XTSWHCFJMONXSVGPVDLY____
+Content-Type: text/html; charset=iso-8859-15
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline;
+	modification-date="Wed, 22 Mar 2017 15:21:55 -0500"
+
+<HTML xmlns=3D"http://www.w3.org/1999/xhtml">
+<BODY>
+<DIV>Hello Chloe</DIV>
+</BODY>
+</HTML>
+--____XTSWHCFJMONXSVGPVDLY____
+Content-Type: application/octet-stream; name="abc.xyz"
+Content-Description: abcefghijklmnopqrstuvwxyz01234567890abcefghijklmnopqrstuvwxyz01234567890abcefghijklmnopqrstuvwxyz01234567890.xyz
+Content-Disposition: attachment; filename*0="abcefghijklmnopqrstuvwxyz01234567890abcefghijklmnopqrstuvwxyz01234567890abce"; filename*1="fghijklmnopqrstuvwxyz01234567890.xyz";
+Content-Transfer-Encoding: base64
+
+R0lGODlhHgHCAPf/AIOPr9GvT7SFcZZjVTEuMLS1tZKUlJN0Znp4eEA7PV1aWvz8+8V6Zl1BNYxX
+HvOZ1/zmOd95agUEADs=
+--____XTSWHCFJMONXSVGPVDLY____
+Content-ID: <VFXVGHAGXNMI.36b3148cbf284ba18d35bdd8386ac266>
+Content-Type: image/xxx
+Content-Transfer-Encoding: base64
+
+R0lGODlhAQABAPAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==
+--____XTSWHCFJMONXSVGPVDLY____--
+
+--____NOIBTUQXSYRVOOAFLCHY____--
+"""
+
 raw_email_encoded_encoding_charset_contains_a_minus = b"""Delivered-To: <receiver@example.org>
 Return-Path: <sender@example.org>
 Message-ID: <74836CF6FF9B1965927DE7EE8A087483@NXOFGRQFQW2>
@@ -360,6 +413,15 @@ class TestParser(unittest.TestCase):
         self.assertEqual('application/octet-stream', attachment['content-type'])
         self.assertEqual(71, attachment['size'])
         self.assertEqual('abc.xyz', attachment['filename'])
+        self.assertTrue(attachment['content'])
+
+    def test_parse_attachment_with_long_filename(self):
+        parsed_email = parse_email(raw_email_with_long_filename_attachment)
+        self.assertEqual(1, len(parsed_email.attachments))
+        attachment = parsed_email.attachments[0]
+        self.assertEqual('application/octet-stream', attachment['content-type'])
+        self.assertEqual(71, attachment['size'])
+        self.assertEqual('abcefghijklmnopqrstuvwxyz01234567890abcefghijklmnopqrstuvwxyz01234567890abcefghijklmnopqrstuvwxyz01234567890.xyz', attachment['filename'])
         self.assertTrue(attachment['content'])
 
     def test_parse_email_accept_if_declared_charset_contains_a_minus_character(self):


### PR DESCRIPTION
Section 3 of RFC 2184 details how attachments with file names that are longer than 76 characters should be dealt with (https://tools.ietf.org/html/rfc2184#section-3).  Rather than overwriting the filename field of the attachments, if the content-disposition includes multiple entries of the form filename*X where X is an integer, these values should be concatenated.