### PR TITLE
Update parser.py

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -112,7 +112,7 @@ def parse_attachment(message_part):
                     name, value = decode_param(param)
 
                     # Check for split filename
-                    s_name = name.split("*")
+                    s_name = name.rstrip('*').split("*")
                     if s_name[0] == 'filename':
                         # If this is a split file name - use the number after the * as an index to insert this part
                         if len(s_name) > 1:


### PR DESCRIPTION
Construct the filename of the attachment correctly if the filename
a) uses the encoding defined in RFC 5987 (filename* instead of filename)
b) and it is sort therefore no needed to break up into  smaller units that are amenable to line wrapping (Parameter Value Continuations defined in RFC2184).

For example: 
Content-Disposition: attachment;
 filename*=UTF-8''%C3%A9%6B%65%7A%65%74%65%73