### PR TITLE
fix for #196

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -105,25 +105,9 @@ def parse_attachment(message_part):
                 'content': io.BytesIO(file_data),
                 'content-id': message_part.get("Content-ID", None)
             }
-            filename = message_part.get_param('name')
-            filename_parts = []
-            for param in dispositions[1:]:
-                if param:
-                    name, value = decode_param(param)
 
-                    # Check for split filename
-                    s_name = name.rstrip('*').split("*")
-                    if s_name[0] == 'filename':
-                        # If this is a split file name - use the number after the * as an index to insert this part
-                        if len(s_name) > 1:
-                            filename_parts.insert(int(s_name[1]),value[1:-1] if value.startswith('"') else value)
-                        else:
-                            filename_parts.insert(0,value[1:-1] if value.startswith('"') else value)
-
-                    if 'create-date' in name:
-                        attachment['create-date'] = value
-
-            attachment['filename'] = "".join(filename_parts)
+            attachment['filename'] =  message_part.get_filename()
+            
             return attachment
 
     return None


### PR DESCRIPTION
For some pdf attachments the filename field is empty. This is because sometimes the file name is indicated in the content-type field.

https://docs.python.org/3/library/email.message.html#email.message.EmailMessage
**get_filename**(failobj=None)¶
Return the value of the filename parameter of the Content-Disposition header of the message. If the header does not have a filename parameter, this method falls back to looking for the name parameter on the Content-Type header. If neither is found, or the header is missing, then failobj is returned. The returned string will always be unquoted as per email.utils.unquote().