### PR TITLE
Avoiding the error - ValueError: invalid literal for int() with base 10

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -115,7 +115,7 @@ def parse_attachment(message_part):
                     s_name = name.rstrip('*').split("*")
                     if s_name[0] == 'filename':
                         # If this is a split file name - use the number after the * as an index to insert this part
-                        if len(s_name) > 1:
+                        if len(s_name) > 1 and s_name[1] != '':
                             filename_parts.insert(int(s_name[1]),value[1:-1] if value.startswith('"') else value)
                         else:
                             filename_parts.insert(0,value[1:-1] if value.startswith('"') else value)


### PR DESCRIPTION
Traceback (most recent call last):
  File "/opt/mailbox/inbox.py", line 161, in read_imap
    for uid, message in unread_inbox_messages:
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/messages.py", line 55, in _fetch_email_list
    yield uid, self._fetch_email(uid)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/messages.py", line 44, in _fetch_email
    parser_policy=self.parser_policy)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 155, in fetch_email_by_uid
    email_object = parse_email(raw_email, policy=parser_policy)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 212, in parse_email
    attachment = parse_attachment(part)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 122, in parse_attachment
    filename_parts.insert(int(s_name[1]),value[1:-1] if value.startswith('"') else value)
ValueError: invalid literal for int() with base 10: ''


I think the problem is because (not sure):
For some pdf attachments the filename field is empty. This is because sometimes the file name is indicated in the content-type field.

This simple change avoid the whole script loop being stuck