### PR TITLE
Fix binascii.Error: Incorrect padding

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -70,17 +70,25 @@ def decode_param(param):
     values = v.split('\n')
     value_results = []
     for value in values:
-        match = re.search(r'=\?((?:\w|-)+)\?([QB])\?(.+)\?=', value)
+        match = re.findall(r'=\?((?:\w|-)+)\?([QB])\?(.+?)\?=', value)
         if match:
-            encoding, type_, code = match.groups()
-            if type_ == 'Q':
-                value = quopri.decodestring(code)
-            elif type_ == 'B':
-                value = base64.decodebytes(code.encode())
-            value = str_encode(value, encoding)
+            for encoding, type_, code in match:
+                if type_ == 'Q':
+                    value = quopri.decodestring(code)
+                elif type_ == 'B':
+                    value = code.encode()
+                    missing_padding = len(value) % 4
+
+                    if missing_padding:
+                        value += b"=" * (4 - missing_padding)
+
+                value = str_encode(value, encoding)
+
             value_results.append(value)
+
             if value_results:
                 v = ''.join(value_results)
+
     logger.debug("Decoded parameter {} - {}".format(name, v))
     return name, v
 


### PR DESCRIPTION
When decode_param receives a value like this:
"=?ISO-8859-1?B?TEdGIC0gUGFzc28gYSBQYXNzbyAtIEZh?= =?ISO-8859-1?B?dHVyYW1lbnRvIEVsZXRy9G5pY28ucGRm?="

It fails to decode the base64 correctly, and it gives the error:

File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/messages.py", line 55, in _fetch_email_list
    yield uid, self._fetch_email(uid)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/messages.py", line 44, in _fetch_email
    parser_policy=self.parser_policy)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 155, in fetch_email_by_uid
    email_object = parse_email(raw_email, policy=parser_policy)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 212, in parse_email
    attachment = parse_attachment(part)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 115, in parse_attachment
    name, value = decode_param(param)
  File "/usr/local/lib/python3.6/site-packages/imbox-0.9.8-py3.6.egg/imbox/parser.py", line 80, in decode_param
    value = base64.decodebytes(code.encode())
  File "/usr/lib64/python3.6/base64.py", line 546, in decodebytes
    return binascii.a2b_base64(s)
binascii.Error: Incorrect padding

So i changed the regular expression and started using findall instead, i also added a "fixer" for invalid base64 blocks, it adds "=" to the end of it if needed.