### PR TITLE
Fix ignored headers + unnecessary major version check

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -154,7 +154,8 @@ def fetch_email_by_uid(uid, connection, parser_policy):
     message, data = connection.uid('fetch', uid, '(BODY.PEEK[] FLAGS)')
     logger.debug("Fetched message for UID {}".format(int(uid)))
 
-    raw_headers, raw_email = data[0]
+    raw_headers = data[0][0] + data[1]
+    raw_email = data[0][1]
 
     email_object = parse_email(raw_email, policy=parser_policy)
     flags = parse_flags(raw_headers.decode())

--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -5,7 +5,6 @@ import email
 import chardet
 import base64
 import quopri
-import sys
 import time
 from datetime import datetime
 from email.header import decode_header
@@ -168,8 +167,7 @@ def parse_flags(headers):
     """Copied from https://github.com/girishramnani/gmail/blob/master/gmail/message.py"""
     if len(headers) == 0:
         return []
-    if sys.version_info[0] == 3:
-        headers = bytes(headers, "ascii")
+    headers = bytes(headers, "ascii")
     return list(imaplib.ParseFlags(headers))
 
 


### PR DESCRIPTION
I was wondering why Outlook emails didn't have any flags. Turns out `data[1]` seems to contain the end of `data[0][0]`. For the 3 other servers I have tested, `data[1]` is just a single closing parenthesis but in the case of Outlook it contains the flags.
Here's the an example of the output of
```python
print(data[0][0])
print(data[1])
```
for Gmail:
```python
b'1 (UID 9854 FLAGS (\\Seen) BODY[] {25498}'
b')'
```
and here it is for Outlook:
```python
b'1 (BODY[] {5984}'
b' FLAGS (\\Seen) UID 354)'
```
so the fix is to simply concatenate them.
I hope this doesn't break things for other servers, if it does we can just add a check for the length of `data`.

Also fixed a version check that's not necessary since Imbox is for 3.3+.