### PR TITLE
Date handling improvement and various fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE
 include MANIFEST.in
-include README.rst
+include README.md
 include CHANGELOG.md
 graft tests

--- a/imbox/query.py
+++ b/imbox/query.py
@@ -1,12 +1,14 @@
 import datetime
 
+from imbox.utils import date_to_date_text
+
 
 def build_search_query(imap_attribute_lookup, **kwargs):
     query = []
     for name, value in kwargs.items():
         if value is not None:
             if isinstance(value, datetime.date):
-                value = value.strftime('%d-%b-%Y')
+                value = date_to_date_text(value)
             if isinstance(value, str) and '"' in value:
                 value = value.replace('"', "'")
             query.append(imap_attribute_lookup[name].format(value))

--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -1,4 +1,6 @@
+import datetime
 import logging
+from imaplib import Time2Internaldate
 logger = logging.getLogger(__name__)
 
 
@@ -14,3 +16,10 @@ def str_decode(value='', encoding=None, errors='strict'):
         return value.decode(encoding or 'utf-8', errors=errors)
     else:
         raise TypeError("Cannot decode '{}' object".format(value.__class__))
+
+
+def date_to_date_text(date):
+    """Return a date in the RFC 3501 date-text syntax"""
+    tzutc = datetime.timezone.utc
+    dt = datetime.datetime.combine(date, datetime.time.min, tzutc)
+    return Time2Internaldate(dt)[1:12]

--- a/imbox/utils.py
+++ b/imbox/utils.py
@@ -5,7 +5,10 @@ logger = logging.getLogger(__name__)
 
 
 def str_encode(value='', encoding=None, errors='strict'):
-    logger.debug("Encode str {} with and errors {}".format(value, encoding, errors))
+    logger.debug("Encode str {value} with encoding {encoding} and errors {errors}".format(
+        value=value,
+        encoding=encoding,
+        errors=errors))
     return str(value, encoding, errors)
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name='imbox',
     version=get_version(),
     description="Python IMAP for Human beings",
-    long_description=read('README.rst'),
+    long_description=read('README.md'),
     keywords='email, IMAP, parsing emails',
     author='Martin Rusev',
     author_email='martin@amon.cx',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ def get_version():
 
 
 def read(filename):
-    return open(os.path.join(os.path.dirname(__file__), filename)).read()
+    with open(os.path.join(os.path.dirname(__file__), filename)) as f:
+        return f.read()
 
 
 setup(


### PR DESCRIPTION
Fixed a few things and most importantly the date handling is now locale independent. I thought `strftime` `%b`'s reliance on the locale was the cause for #160 and #189 but after some testing it seems like as soon as you pass a wrong month (as in not the first 3 letters of a month in English like the [RFC](https://datatracker.ietf.org/doc/html/rfc3501#page-84) specifies it) you get an error (`imaplib.IMAP4.error: UID command error: BAD [b'Error in IMAP command UID SEARCH: Invalid search date parameter (0.001 + 0.000 secs).']`) so I don't think these two issues are related to a locale issue.