### PR TITLE
[Fix] parse_attachment > cannot parse name

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -142,11 +142,15 @@ def parse_attachment(message_part):
                     # Check for split filename
                     s_name = name.rstrip('*').split("*")
                     if s_name[0] == 'filename':
-                        # If this is a split file name - use the number after the * as an index to insert this part
-                        if len(s_name) > 1 and s_name[1] != '':
-                            filename_parts.insert(int(s_name[1]),value[1:-1] if value.startswith('"') else value)
-                        else:
-                            filename_parts.insert(0,value[1:-1] if value.startswith('"') else value)
+                        try:
+                            # If this is a split file name - use the number after the * as an index to insert this part
+                            if len(s_name) > 1 and s_name[1] != '':
+                                filename_parts.insert(int(s_name[1]),value[1:-1] if value.startswith('"') else value)
+                            else:
+                                filename_parts.insert(0,value[1:-1] if value.startswith('"') else value)
+                        except Exception as err:
+                            logger.debug('Parse attachment name error: %s', err)
+                            filename_parts.insert(0, value)
 
                     if 'create-date' in name:
                         attachment['create-date'] = value


### PR DESCRIPTION
Due to some reasons, the attachment's name cannot be parsed. 
I suggest, in this case, we can add try-catch to prevent crash function. 
Refer issue: https://github.com/martinrusev/imbox/issues/227