### PR TITLE
fix append and join of param parts

### DIFF
--- a/imbox/parser.py
+++ b/imbox/parser.py
@@ -86,10 +86,10 @@ def decode_param(param):
 
                 value = str_encode(value, encoding)
 
-            value_results.append(value)
+                value_results.append(value)
 
-            if value_results:
-                v = ''.join(value_results)
+    if value_results:
+        v = ''.join(value_results)
 
     logger.debug("Decoded parameter {} - {}".format(name, v))
     return name, v


### PR DESCRIPTION
Hi, I think the indentation was messed up in `decode_param`. It make sense to me that value is appended to `value_results` at the and of the innermost for loop, and the `value_results` are joined outside the outermost loop, just before returning.

This was made clear with an email with an attachment whose filename contained a newline "\n", where only the part before the newline was actually present in the resulting filename.

Thanks
Regards 
