### PR TITLE
Raise an error when folder selection is unsuccessful

### DIFF
--- a/imbox/imbox.py
+++ b/imbox/imbox.py
@@ -88,8 +88,10 @@ class Imbox:
             messages_class = GmailMessages
 
         if folder:
-            self.connection.select(
+            status, data = self.connection.select(
                 messages_class.FOLDER_LOOKUP.get((folder.lower())) or folder)
+            if status != "OK":
+                raise imaplib.IMAP4.error(data[-1])
             msg = " from folder '{}'".format(folder)
             del kwargs['folder']
         else:


### PR DESCRIPTION
Fixes #38.
Now, if you try to search a nonexistent folder, you get the error message that was returned by the mail server instead of a misleading message `"command SEARCH illegal in state AUTH, only allowed in states SELECTED"`. My server returns `"[NONEXISTENT] Folder not exists"`.